### PR TITLE
Feature download kiosk image

### DIFF
--- a/user-data
+++ b/user-data
@@ -20,17 +20,15 @@ timezone: Europe/Copenhagen
 runcmd:
   - localectl set-x11-keymap "dk" pc105
   - setupcon -k --force || true
-  - 'echo Downloader OS2BorgerPC Kiosk RPI Image'
-  - 'curl -Lo os2borgerpc-kiosk-rpi-image.zip "https://github.com/os2borgerpc/os2borgerpc-kiosk-rpi-image/archive/refs/heads/main.zip"'
   - 'apt-get update'
-  - 'apt-get install unzip'
-  - 'unzip os2borgerpc-kiosk-rpi-image.zip'
-  - 'rm os2borgerpc-kiosk-rpi-image.zip'
-  - 'chmod +x os2borgerpc-kiosk-rpi-image-main/scripts/*.sh'
-  - 'touch os2borgerpc-kiosk-rpi-image-main/scripts/VERSION'
-  - 'echo 2.0.0 >> os2borgerpc-kiosk-rpi-image-main/scripts/VERSION'
-  - 'mv os2borgerpc-kiosk-rpi-image-main/scripts/* /usr/local/bin/'
-  - 'rm -r os2borgerpc-kiosk-rpi-image-main'
+  - 'apt-get install git -y'
+  - 'echo Downloader OS2BorgerPC Kiosk Image to use the script package'
+  - 'git clone https://github.com/OS2borgerPC/os2borgerpc-kiosk-image.git'
+  - 'chmod +x os2borgerpc-kiosk-image/image/ubuntu-image/scripts/*.sh'
+  - 'echo "2.0.0" | tee -a os2borgerpc-kiosk-image/image/ubuntu-image/scripts/VERSION
+  - 'mv os2borgerpc-kiosk-image/image/ubuntu-image/scripts/* /usr/local/bin/'
+  - 'rm -r os2borgerpc-kiosk-image'
+  - 'apt-get remove git -y'
   - 'cd /usr/local/bin'
   - './install_dependencies.sh'
   - 'sed -ir "s/^[#]*\s*preserve_hostname:.*/preserve_hostname: true/" /etc/cloud/cloud.cfg'

--- a/user-data
+++ b/user-data
@@ -22,14 +22,13 @@ runcmd:
   - setupcon -k --force || true
   - 'apt-get update'
   - 'apt-get install git -y'
-  - 'echo Downloader OS2BorgerPC Kiosk Image to use the script package'
+  - 'echo Downloader OS2BorgerPC Kiosk Image to use the scripts'
   - 'git clone https://github.com/OS2borgerPC/os2borgerpc-kiosk-image.git'
   - 'chmod +x os2borgerpc-kiosk-image/image/ubuntu-image/scripts/*.sh'
-  - 'echo "2.0.0" | tee -a os2borgerpc-kiosk-image/image/ubuntu-image/scripts/VERSION
   - 'mv os2borgerpc-kiosk-image/image/ubuntu-image/scripts/* /usr/local/bin/'
+  - 'mv os2borgerpc-kiosk-image/VERSION /usr/local/bin/VERSION'
+  - 'mv os2borgerpc-kiosk-image/config.cfg /usr/local/bin/config.cfg'
   - 'rm -r os2borgerpc-kiosk-image'
-  - 'apt-get remove git -y'
   - 'cd /usr/local/bin'
   - './install_dependencies.sh'
   - 'sed -ir "s/^[#]*\s*preserve_hostname:.*/preserve_hostname: true/" /etc/cloud/cloud.cfg'
- 

--- a/user-data
+++ b/user-data
@@ -12,7 +12,7 @@ users:
   groups: users,adm,dialout,audio,netdev,video,plugdev,cdrom,games,input,gpio,spi,i2c,render,sudo
   shell: /bin/bash
   lock_passwd: false
-  plain_text_passwd: superuser
+  plain_text_passwd: 'superuser'
 
 ssh_pwauth: true
 
@@ -25,11 +25,10 @@ runcmd:
   - 'echo Downloader OS2BorgerPC Kiosk Image to use the script package'
   - 'git clone https://github.com/OS2borgerPC/os2borgerpc-kiosk-image.git'
   - 'chmod +x os2borgerpc-kiosk-image/image/ubuntu-image/scripts/*.sh'
-  - 'echo "2.0.0" | tee -a os2borgerpc-kiosk-image/image/ubuntu-image/scripts/VERSION
+  - 'echo "2.0.0" | tee -a os2borgerpc-kiosk-image/image/ubuntu-image/scripts/VERSION'
   - 'mv os2borgerpc-kiosk-image/image/ubuntu-image/scripts/* /usr/local/bin/'
   - 'rm -r os2borgerpc-kiosk-image'
   - 'apt-get remove git -y'
   - 'cd /usr/local/bin'
   - './install_dependencies.sh'
   - 'sed -ir "s/^[#]*\s*preserve_hostname:.*/preserve_hostname: true/" /etc/cloud/cloud.cfg'
- 


### PR DESCRIPTION
Updates the RPI Kiosk Image to be compatible with KITs updates to the kiosk image and the client. 

The tecknical implementation has changed. We now clone the os2borgerpc-kiosk-image repo to reuse the connect-scripts. Prior version had a copy of the connect-scripts stored in this project. 